### PR TITLE
disable local e2e on non-linux

### DIFF
--- a/local_e2e/local_e2e_suite_test.go
+++ b/local_e2e/local_e2e_suite_test.go
@@ -1,6 +1,8 @@
 package local_e2e
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/solo-io/gloo-testing/helpers/local"
@@ -17,6 +19,11 @@ var (
 )
 
 func TestLocalE2e(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		fmt.Println("local E2E Suite only runs on Linux")
+		return
+	}
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "LocalE2e Suite")
 }


### PR DESCRIPTION
allows us to run tests from root without failing on non Linux OS